### PR TITLE
added the r_fogMinOpaqueDistance cvar

### DIFF
--- a/trunk/code/renderer/tr_init.c
+++ b/trunk/code/renderer/tr_init.c
@@ -158,6 +158,7 @@ cvar_t	*r_saveFontData;
 cvar_t	*r_GLlibCoolDownMsec;
 
 cvar_t	*r_backEndMegs;
+cvar_t	*r_fogMinOpaqueDistance; // myT: overrides the fog's clipping distance on map load
 
 cvar_t *r_framebuffer;
 cvar_t *r_framebuffer_bloom;
@@ -795,6 +796,8 @@ void R_Register( void )
 	r_smp = ri.Cvar_Get( "r_smp", "0", CVAR_ARCHIVE | CVAR_LATCH);
 	r_ignoreFastPath = ri.Cvar_Get( "r_ignoreFastPath", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_backEndMegs = ri.Cvar_Get ( "r_backEndMegs", "2", CVAR_ARCHIVE | CVAR_LATCH );
+	r_fogMinOpaqueDistance = ri.Cvar_Get("r_fogMinOpaqueDistance", "768", CVAR_ARCHIVE);
+
 	//
 	// temporary latched variables that can only change over a restart
 	//

--- a/trunk/code/renderer/tr_shader.c
+++ b/trunk/code/renderer/tr_shader.c
@@ -38,6 +38,8 @@ static	shader_t*		hashTable[FILE_HASH_SIZE];
 #define MAX_SHADERTEXT_HASH		2048
 static char **shaderTextHashTable[MAX_SHADERTEXT_HASH];
 
+extern cvar_t *r_fogMinOpaqueDistance;
+
 /*
 //I think I will leave that shit here because I'd probably need it one day...
 #define MAX_IGNORE_CONDITIONS 23
@@ -1666,7 +1668,7 @@ static qboolean ParseShader( char **text )
 				ri.Printf( PRINT_WARNING, "WARNING: missing parm for 'fogParms' keyword in shader '%s'\n", shader.name );
 				continue;
 			}
-			shader.fogParms.depthForOpaque = atof( token );
+			shader.fogParms.depthForOpaque = max(r_fogMinOpaqueDistance->value, atof(token));
 
 			// skip any old gradient directions
 			SkipRestOfLine( text );


### PR DESCRIPTION
The r_fogMinOpaqueDistance CVar was added to override the fog's clipping distance on map load.
This will serve as a quick fix for q3mme's broken fog rendering.
